### PR TITLE
Add nil check to ctx.Set

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -90,6 +90,9 @@ func (ctx *Context) Get(key string) any {
 
 // Set sets a context value, useful in passing data to other handlers down the chain
 func (ctx *Context) Set(key string, val any) {
+	if ctx.data == nil {
+		ctx.data = make(M)
+	}
 	ctx.data[key] = val
 }
 


### PR DESCRIPTION
panic happens when trying to set this for a test

```
ctx := &gserv.Context{
		ResponseWriter: drw,
		Codec:          gserv.DefaultCodec,
		Params:         args.PathParams,
		ReqQuery:       args.QueryParams,
		Req:            r,
	}
	ctx.Set(RoleContextKey, args.Role)
```